### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/steggert0240/293a1920-b93a-42ad-ab86-75480656e2b3/e961c23a-a046-4f98-ae67-6a1857730ac5/_apis/work/boardbadge/2086aece-4df5-4ca3-9492-83c505354eb6)](https://dev.azure.com/steggert0240/293a1920-b93a-42ad-ab86-75480656e2b3/_boards/board/t/e961c23a-a046-4f98-ae67-6a1857730ac5/Microsoft.RequirementCategory)
 # l33tgov
 l33tgov.com a modern, cititizen centric government


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/steggert0240/293a1920-b93a-42ad-ab86-75480656e2b3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.